### PR TITLE
Fix: Ensure phone number field is disabled in view mode dialog

### DIFF
--- a/src/app/components/customer-dialog/customer-dialog.ts
+++ b/src/app/components/customer-dialog/customer-dialog.ts
@@ -55,6 +55,7 @@ export class CustomerDialog implements OnDestroy {
       this.lastName.disable();
       this.email.disable();
       this.isActive.disable();
+      this.phoneNumber.disable();
     }
     // dynamic disableClose: prevent closing when the user made changes
     // initially allow close (unless in view mode where fields are disabled)


### PR DESCRIPTION
When clicking a row in the customer table to view a customer, all fields in the dialog should be consistently disabled and greyed out. Previously, the phone number field was not being disabled in view mode, making it visually inconsistent with other fields.

This change adds phoneNumber.disable() to the view mode logic in CustomerDialog component to ensure all form fields are consistently disabled in view mode.