### PR TITLE
feat: Add carriers management page with CRUD functionality

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -3,6 +3,7 @@
   <span style="flex: 1"></span>
   <button mat-button routerLink="/customers">Customers Page</button>
   <button mat-button routerLink="/products">Products Page</button>
+  <button mat-button routerLink="/carriers">Carriers Page</button>
   <button mat-button routerLink="/user">User Page</button>
   <app-theme-selector></app-theme-selector>
 </mat-toolbar>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { CustomersTable } from './components/customers-table/customers-table';
 import { UserPage } from './components/user-page/user-page';
 import { ProductsPage } from './components/products-page/products-page';
+import { CarriersPage } from './components/carriers-page/carriers-page';
 import { PendingChangesGuard } from './guards/pending-changes.guard';
 
 export const routes: Routes = [
@@ -26,5 +27,6 @@ export const routes: Routes = [
     runGuardsAndResolvers: 'always'
   },
   { path: 'user', component: UserPage },
-  { path: 'products', component: ProductsPage }
+  { path: 'products', component: ProductsPage },
+  { path: 'carriers', component: CarriersPage }
 ];

--- a/src/app/components/carrier-dialog/carrier-dialog.html
+++ b/src/app/components/carrier-dialog/carrier-dialog.html
@@ -1,0 +1,44 @@
+<div class="carrier-dialog">
+  <h2 matDialogTitle>
+    {{ isEditing ? 'Edit Carrier' : 'Add New Carrier' }}
+  </h2>
+
+  <mat-dialog-content>
+    <form [formGroup]="carrierForm" (ngSubmit)="onSubmit()" class="carrier-form">
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Carrier Name</mat-label>
+        <input matInput formControlName="name" required>
+        @if (carrierForm.get('name')?.invalid && carrierForm.get('name')?.touched) {
+          <mat-error>
+            @if (carrierForm.get('name')?.errors?.['required']) {
+              Carrier name is required
+            }
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Tracking URL</mat-label>
+        <input matInput formControlName="trackingUrl" required>
+        @if (carrierForm.get('trackingUrl')?.invalid && carrierForm.get('trackingUrl')?.touched) {
+          <mat-error>
+            @if (carrierForm.get('trackingUrl')?.errors?.['required']) {
+              Tracking URL is required
+            }
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-checkbox formControlName="isActive">
+        Active
+      </mat-checkbox>
+    </form>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button (click)="onCancel()">Cancel</button>
+    <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="carrierForm.invalid">
+      {{ isEditing ? 'Update' : 'Add' }}
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/components/carrier-dialog/carrier-dialog.scss
+++ b/src/app/components/carrier-dialog/carrier-dialog.scss
@@ -1,0 +1,11 @@
+.carrier-dialog {
+  .full-width {
+    width: 100%;
+  }
+
+  .carrier-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}

--- a/src/app/components/carrier-dialog/carrier-dialog.ts
+++ b/src/app/components/carrier-dialog/carrier-dialog.ts
@@ -1,0 +1,87 @@
+import {
+  Component,
+  Inject,
+  OnInit,
+  inject,
+  ChangeDetectionStrategy,
+  signal
+} from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Carrier } from '../../models/carrier';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+export interface CarrierDialogData {
+  carrier?: Carrier;
+}
+
+@Component({
+  selector: 'app-carrier-dialog',
+  imports: [
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatCheckboxModule,
+    ReactiveFormsModule,
+    CommonModule
+  ],
+  templateUrl: './carrier-dialog.html',
+  styleUrls: ['./carrier-dialog.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CarrierDialog implements OnInit {
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<CarrierDialog>);
+  @Inject(MAT_DIALOG_DATA) public data: CarrierDialogData;
+
+  carrierForm!: FormGroup;
+  isEditing = !!this.data.carrier;
+  hasUnsavedChanges = signal(false);
+
+  ngOnInit(): void {
+    this.initializeForm();
+  }
+
+  private initializeForm(): void {
+    this.carrierForm = this.fb.group({
+      name: [this.data.carrier?.name || '', Validators.required],
+      trackingUrl: [this.data.carrier?.trackingUrl || '', Validators.required],
+      isActive: [this.data.carrier?.isActive || true]
+    });
+
+    // Listen for form changes to track unsaved changes
+    this.carrierForm.valueChanges.subscribe(() => {
+      this.hasUnsavedChanges.set(true);
+    });
+  }
+
+  onSubmit(): void {
+    if (this.carrierForm.valid) {
+      const formData = this.carrierForm.value;
+      const carrierData: Carrier = {
+        ...this.data.carrier,
+        ...formData,
+        id: this.data.carrier?.id || 0,
+        createdAt: this.data.carrier?.createdAt || new Date(),
+        updatedAt: new Date()
+      };
+
+      this.dialogRef.close(carrierData);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  hasUnsavedChangesFn(): boolean {
+    return this.hasUnsavedChanges();
+  }
+}

--- a/src/app/components/carriers-page/carriers-page.html
+++ b/src/app/components/carriers-page/carriers-page.html
@@ -1,0 +1,84 @@
+<mat-toolbar>
+  <span>Carriers Management</span>
+  <span style="flex: 1"></span>
+  <button mat-raised-button color="primary" (click)="addCarrier()" class="add-button">
+    <mat-icon>add</mat-icon>
+    Add Carrier
+  </button>
+</mat-toolbar>
+
+<div class="carriers-page">
+  <div class="toolbar">
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Filter carriers</mat-label>
+      <input matInput (keyup)="applyFilter($event.target.value)" [value]="filterValue">
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+  </div>
+
+  <div class="table-container">
+    @if (loading()) {
+      <div class="loading-container">
+        <mat-spinner></mat-spinner>
+      </div>
+    }
+
+    @if (!loading() && error()) {
+      <div class="error-container">
+        <p>{{ error() }}</p>
+      </div>
+    }
+
+    @if (!loading() && !error()) {
+      <table mat-table [dataSource]="dataSource" matSort class="carriers-table">
+        <ng-container matColumnDef="select">
+          <th mat-header-cell *matHeaderCellDef>
+            <mat-checkbox (change)="$event ? toggleAllRows() : null"
+                          [checked]="isAllSelected()"
+                          [indeterminate]="selection.hasValue() && !isAllSelected()">
+            </mat-checkbox>
+          </th>
+          <td mat-cell *matCellDef="let row">
+            <mat-checkbox (click)="$event.stopPropagation()"
+                          (change)="$event ? selection.toggle(row) : null"
+                          [checked]="selection.isSelected(row)">
+            </mat-checkbox>
+          </td>
+        </ng-container>
+
+        @for (column of columns; track column.key) {
+          <ng-container [matColumnDef]="column.key">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>
+              {{ column.label }}
+            </th>
+            <td mat-cell *matCellDef="let carrier">
+              @if (column.key === 'createdAt' || column.key === 'updatedAt') {
+                {{ carrier[column.key] | date:'short' }}
+              } @else if (column.key === 'isActive') {
+                <mat-checkbox [checked]="carrier[column.key]" disabled></mat-checkbox>
+              } @else {
+                {{ carrier[column.key] }}
+              }
+            </td>
+          </ng-container>
+        }
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+
+      <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" showFirstLastButtons></mat-paginator>
+    }
+  </div>
+
+  <div class="actions-container">
+    <button mat-button (click)="editCarrier()" [disabled]="selection.selected.length !== 1">
+      <mat-icon>edit</mat-icon>
+      Edit Selected
+    </button>
+    <button mat-button (click)="deleteCarriers()" [disabled]="selection.selected.length === 0">
+      <mat-icon>delete</mat-icon>
+      Delete Selected
+    </button>
+  </div>
+</div>

--- a/src/app/components/carriers-page/carriers-page.scss
+++ b/src/app/components/carriers-page/carriers-page.scss
@@ -1,0 +1,56 @@
+.carriers-page {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    margin-bottom: 16px;
+    gap: 16px;
+  }
+
+  .filter-field {
+    flex: 1;
+  }
+
+  .table-container {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .carriers-table {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .loading-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 1;
+  }
+
+  .error-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 1;
+    padding: 16px;
+  }
+
+  .actions-container {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+    padding: 8px;
+    border-top: 1px solid #ccc;
+  }
+
+  .add-button {
+    margin-left: 16px;
+  }
+}

--- a/src/app/components/carriers-page/carriers-page.ts
+++ b/src/app/components/carriers-page/carriers-page.ts
@@ -1,0 +1,196 @@
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  AfterViewInit,
+  inject,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  effect,
+  signal
+} from '@angular/core';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Carrier } from '../../models/carrier';
+import { CarrierService } from '../../services/carrier.service';
+import { FormsModule } from '@angular/forms';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { SelectionModel } from '@angular/cdk/collections';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CarrierDialog, CarrierDialogData } from '../carrier-dialog/carrier-dialog';
+import { ConfirmationDialog, ConfirmationDialogData } from '../confirmation-dialog/confirmation-dialog';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-carriers-page',
+  imports: [
+    MatTableModule,
+    MatSnackBarModule,
+    MatSortModule,
+    MatPaginatorModule,
+    FormsModule,
+    DragDropModule,
+    MatCheckboxModule,
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatDialogModule,
+    MatToolbarModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './carriers-page.html',
+  styleUrls: ['./carriers-page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CarriersPage implements OnInit, AfterViewInit {
+  private carrierService = inject(CarrierService);
+  private snackBar = inject(MatSnackBar);
+  private dialog = inject(MatDialog);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+
+  columns = [
+    { key: 'id', label: 'ID' },
+    { key: 'name', label: 'Name' },
+    { key: 'trackingUrl', label: 'Tracking URL' },
+    { key: 'isActive', label: 'Active' },
+    { key: 'createdAt', label: 'Created' },
+    { key: 'updatedAt', label: 'Updated' }
+  ];
+  displayedColumns = ['select', ...this.columns.map(c => c.key)];
+  selection = new SelectionModel<Carrier>(true, []);
+  dataSource = new MatTableDataSource<Carrier>();
+  filterValue = '';
+  private dialogOpen = signal(false);
+  private activeDialogRef: MatDialogRef<CarrierDialog> | null = null;
+
+  carriers = this.carrierService.carriers;
+  loading = this.carrierService.loading;
+  error = this.carrierService.error;
+
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  readonly errorEffect = effect(() => {
+    const msg = this.error();
+    if (msg) {
+      this.snackBar.open(msg, 'Close', { duration: 4000 });
+    }
+  });
+
+  readonly tableEffect = effect(() => {
+    this.dataSource.data = this.carriers();
+    this.applyFilter(this.filterValue);
+    this.changeDetectorRef.markForCheck();
+  });
+
+  ngOnInit() {
+    this.carrierService.loadCarriers();
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
+  }
+
+  applyFilter(value: string) {
+    this.filterValue = value.trim().toLowerCase();
+    this.dataSource.filter = this.filterValue;
+  }
+
+  isAllSelected() {
+    const numSelected = this.selection.selected.length;
+    const numRows = this.dataSource.data.length;
+    return numSelected === numRows;
+  }
+
+  toggleAllRows() {
+    if (this.isAllSelected()) {
+      this.selection.clear();
+    } else {
+      this.dataSource.data.forEach(row => this.selection.select(row));
+    }
+  }
+
+  openAddDialog() {
+    const ref = this.dialog.open(CarrierDialog, {
+      data: { carrier: undefined },
+      panelClass: 'carrier-dialog',
+      closeOnNavigation: false
+    });
+
+    this.activeDialogRef = ref as MatDialogRef<CarrierDialog>;
+    ref.afterClosed().subscribe((result: Carrier | undefined) => {
+      this.activeDialogRef = null;
+      if (result) {
+        this.carrierService.addCarrier(result);
+        this.snackBar.open('Carrier added successfully', 'Close', { duration: 3000 });
+      }
+    });
+    return ref as MatDialogRef<CarrierDialog>;
+  }
+
+  openEditDialog(carrier: Carrier) {
+    const ref = this.dialog.open(CarrierDialog, {
+      data: { carrier },
+      panelClass: 'carrier-dialog',
+      closeOnNavigation: false
+    });
+
+    this.activeDialogRef = ref as MatDialogRef<CarrierDialog>;
+    ref.afterClosed().subscribe((result: Carrier | undefined) => {
+      this.activeDialogRef = null;
+      if (result) {
+        this.carrierService.updateCarrier(result);
+        this.snackBar.open('Carrier updated successfully', 'Close', { duration: 3000 });
+      }
+    });
+    return ref as MatDialogRef<CarrierDialog>;
+  }
+
+  addCarrier() {
+    this.openAddDialog();
+  }
+
+  editCarrier() {
+    if (this.selection.selected.length !== 1) return;
+    this.openEditDialog(this.selection.selected[0]);
+  }
+
+  deleteCarriers() {
+    if (this.selection.selected.length === 0) return;
+
+    const dialogData: ConfirmationDialogData = {
+      title: 'Delete Carriers',
+      message: `Do you really want to delete ${this.selection.selected.length} carrier(s)?`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel'
+    };
+
+    const dialogRef = this.dialog.open(ConfirmationDialog, {
+      data: dialogData
+    });
+
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (!confirmed) return;
+
+      this.selection.selected.forEach(carrier => {
+        this.carrierService.deleteCarrier(carrier.id);
+      });
+
+      this.selection.clear();
+      this.snackBar.open(`${this.selection.selected.length} carrier(s) deleted successfully`, 'Close', { duration: 3000 });
+      this.changeDetectorRef.markForCheck();
+    });
+  }
+}

--- a/src/app/models/carrier.ts
+++ b/src/app/models/carrier.ts
@@ -1,0 +1,8 @@
+export interface Carrier {
+  id: number;
+  name: string;
+  trackingUrl: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/app/services/carrier.service.ts
+++ b/src/app/services/carrier.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, signal } from '@angular/core';
+import { Carrier } from '../models/carrier';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CarrierService {
+  private carriersSubject = new BehaviorSubject<Carrier[]>([]);
+  public carriers$ = this.carriersSubject.asObservable();
+
+  // Using signals for reactive updates
+  carriers = signal<Carrier[]>([]);
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  constructor() {
+    // Initialize with some sample data
+    this.loadCarriers();
+  }
+
+  loadCarriers(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    // Simulate API call
+    setTimeout(() => {
+      try {
+        const storedCarriers = localStorage.getItem('carriers');
+        const carriers = storedCarriers ? JSON.parse(storedCarriers) : [
+          {
+            id: 1,
+            name: 'UPS',
+            trackingUrl: 'https://www.ups.com/track',
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          },
+          {
+            id: 2,
+            name: 'FedEx',
+            trackingUrl: 'https://www.fedex.com/apps/fedextrack/',
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          },
+          {
+            id: 3,
+            name: 'USPS',
+            trackingUrl: 'https://tools.usps.com/go/TrackConfirmAction_input',
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ];
+
+        this.carriers.set(carriers);
+        this.carriersSubject.next(carriers);
+        this.loading.set(false);
+      } catch (err) {
+        this.error.set('Failed to load carriers');
+        this.loading.set(false);
+      }
+    }, 500);
+  }
+
+  addCarrier(carrier: Omit<Carrier, 'id' | 'createdAt' | 'updatedAt'>): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    setTimeout(() => {
+      try {
+        const newCarrier: Carrier = {
+          ...carrier,
+          id: this.generateId(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        };
+
+        const currentCarriers = this.carriers();
+        const updatedCarriers = [...currentCarriers, newCarrier];
+
+        this.carriers.set(updatedCarriers);
+        this.carriersSubject.next(updatedCarriers);
+        this.saveCarriers(updatedCarriers);
+        this.loading.set(false);
+      } catch (err) {
+        this.error.set('Failed to add carrier');
+        this.loading.set(false);
+      }
+    }, 300);
+  }
+
+  updateCarrier(carrier: Carrier): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    setTimeout(() => {
+      try {
+        const currentCarriers = this.carriers();
+        const updatedCarriers = currentCarriers.map(c =>
+          c.id === carrier.id ? { ...carrier, updatedAt: new Date() } : c
+        );
+
+        this.carriers.set(updatedCarriers);
+        this.carriersSubject.next(updatedCarriers);
+        this.saveCarriers(updatedCarriers);
+        this.loading.set(false);
+      } catch (err) {
+        this.error.set('Failed to update carrier');
+        this.loading.set(false);
+      }
+    }, 300);
+  }
+
+  deleteCarrier(id: number): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    setTimeout(() => {
+      try {
+        const currentCarriers = this.carriers();
+        const updatedCarriers = currentCarriers.filter(c => c.id !== id);
+
+        this.carriers.set(updatedCarriers);
+        this.carriersSubject.next(updatedCarriers);
+        this.saveCarriers(updatedCarriers);
+        this.loading.set(false);
+      } catch (err) {
+        this.error.set('Failed to delete carrier');
+        this.loading.set(false);
+      }
+    }, 300);
+  }
+
+  private generateId(): number {
+    const currentCarriers = this.carriers();
+    return currentCarriers.length > 0
+      ? Math.max(...currentCarriers.map(c => c.id)) + 1
+      : 1;
+  }
+
+  private saveCarriers(carriers: Carrier[]): void {
+    localStorage.setItem('carriers', JSON.stringify(carriers));
+  }
+}


### PR DESCRIPTION
This PR adds a complete carriers management page with the following features:

- Added carriers page with Material Design table
- Implemented full CRUD operations (Create, Read, Update, Delete)
- Added carrier dialog for adding/editing carriers
- Integrated with carrier service for data persistence
- Added confirmation dialogs for destructive operations
- Added routing for the carriers page
- Added link to carriers page in navigation

Features include:
- Local storage persistence
- Loading states with spinner
- Error handling
- Timestamps (createdAt, updatedAt)
- Active/inactive status toggle
- Filtering and sorting capabilities
- Multi-select functionality
- Responsive design

The implementation follows Angular best practices and integrates seamlessly with the existing application structure.